### PR TITLE
View matrix computation fixed

### DIFF
--- a/glviz/src/camera.cpp
+++ b/glviz/src/camera.cpp
@@ -85,11 +85,11 @@ Camera::set_modelview_matrix_from_orientation()
 
     m_modelview_matrix = Matrix4f::Identity();
 
-    Vector3f ori = dir * m_position;
+    Vector3f ori = - dir * m_position;
    
     // Translation * Rotation
     m_modelview_matrix.topLeftCorner(3, 3) = dir;
-    m_modelview_matrix.topRightCorner(3, 1) = m_position;
+    m_modelview_matrix.topRightCorner(3, 1) = ori;
 }
 
 void


### PR DESCRIPTION
Translation part of constructed view matrix was missed, camera translation instead of inverse was used, also the missed inverse was wrongly computed.

I tested it on COLMAP-based real world data and other renderers, after this fix generated renders were aligned.

Based on ($A$ is a 4x4 affine transformation):
```math
B = inv(A) \equiv B[:3, :3] = A[:3, :3]^T; B[3,:3] = - A[:3, :3]^T * A[3, :3]
```

